### PR TITLE
Restrict collabs to only those with write access

### DIFF
--- a/lib/secure_mirror/github_mirror_client.rb
+++ b/lib/secure_mirror/github_mirror_client.rb
@@ -56,10 +56,14 @@ module SecureMirror
       end
     end
 
+    def write_perms?(collab)
+      collab[:permissions][:admin] || collab[:permissions][:push]
+    end
+
     def collaborators(repo, client_name: '')
       wrap_with_github_error_handler(template: COLLABORATOR_ERROR, repo: repo) do
         client = client_from_name(client_name.to_sym)
-        client.collabs(repo).map do |collab|
+        client.collabs(repo).select { |c| write_perms?(c) }.map do |collab|
           [collab[:login], Collaborator.new(collab[:login], false)]
         end.to_h
       end

--- a/spec/secure_mirror_spec.rb
+++ b/spec/secure_mirror_spec.rb
@@ -43,11 +43,15 @@ RSpec.describe SecureMirror, '#unit' do
     context 'pre-receive phase' do
       let(:member_names) { ['apple', 'orange', 'banana'] }
       let(:two_factor_member_names) { ['orange', 'banana'] }
+      let(:read_permissions) { { admin: false, push: false, pull: true } }
+      let(:write_permissions) { { admin: true, push: true, pull: true } }
       let(:two_factor_members) do
-        two_factor_member_names.map { |name| { login: name } }
+        two_factor_member_names.map do |name|
+          { login: name, permissions: write_permissions }
+        end
       end
       let(:members) do
-        member_names.map { |name| { login: name } }
+        member_names.map { |name| { login: name, permissions: read_permissions } }
       end
       let(:github_headers) do
         {


### PR DESCRIPTION
Under certain circumstances, users with read-only access will end up in the set of collaborators returned by GitHub's API.

Those users should not be part of the trust consideration as they cannot write anything into the repository.