### PR TITLE
Added GitHub Actions for CI

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -1,0 +1,21 @@
+name: LLNL Remote Secuirty Testing
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    strategy:
+      matrix:
+        ruby: [ '2.5', '2.6', '2.7']
+    name: Ruby ${{ matrix.ruby }} tests
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: |
+          gem install bundler -v 2.0.1
+          bundle install
+          COVERAGE=true bundle exec rspec
+          ./script/package

--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,6 @@
 vendor/*
 tmp/
 coverage
+
+# generated files
+pkg/

--- a/lib/secure_mirror.rb
+++ b/lib/secure_mirror.rb
@@ -25,8 +25,11 @@ require 'net/http'
 require 'digest/sha2'
 require 'octokit'
 require 'secure_mirror/policy'
+require 'secure_mirror/mirror_client'
 
-Dir[File.join(__dir__, 'secure_mirror', '*.rb')].each { |f| require(f) }
+Dir[File.join(__dir__, 'secure_mirror', '*.rb')].sort
+  .entries.reject{ |f|  f.end_with?('/secure_mirror/mirror_client.rb', '/secure_mirror/policy.rb') }
+  .each { |f| require(f) }
 
 # secure mirror
 module SecureMirror


### PR DESCRIPTION
I wanted to started testing and potentially making contributions to the projects. While getting it setup  locally I figured it would be helpful add some CI testing (also double as a change to use Actions for the first time).

See job run: https://github.com/paulbry/remote-mirror-security/actions/runs/509542093

Note about the `require_relative`, I was seeing the following during CI and running locally in a container:

```

An error occurred while loading spec_helper.
Failure/Error:
    class GitHubMirrorClient < MirrorClient
      MIRROR_ERROR_MAP = {
        Octokit::Unauthorized => SecureMirror::ClientUnauthorized,
        Octokit::Forbidden => SecureMirror::ClientForbidden,
        Octokit::NotFound => SecureMirror::ClientNotFound,
        Octokit::UnprocessableEntity => SecureMirror::ClientGenericError,
        Octokit::ServerError => SecureMirror::ClientServerError
      }.freeze
  
      ORG_MEMBER_ERROR = 'Could not query GitHub org members: %<msg>s'

NameError:
  uninitialized constant SecureMirror::MirrorClient
```

I assumed it was related to the load order, there probably is a better solution?