### PR TITLE
Optional configuration for target specific project_paths.

### DIFF
--- a/spec/secure_mirror/fixtures/config_prefixes.json
+++ b/spec/secure_mirror/fixtures/config_prefixes.json
@@ -8,7 +8,6 @@
     },
     "policy_definition": "default_policy.rb",
     "policy_class_name": "DefaultPolicy",
-    "mirror_check_token": "token",
     "repo_types": {
         "github": {
             "trusted_org": "Foo",


### PR DESCRIPTION
GitLab server 13.2 added a `GL_PROJECT_PATH` environment variable that conveys the path for the target project. This addition introduces an optional configurable list with the “target_path_prefixes” key. Defining this will check the established path against a list of proposed prefixes and only by containing one such prefix will the mirror evaluation be observed.

The goal is to allow instances with already established project/mirroring policies to experiment with remote mirror security on a more targeted set of groups.

The one thing I didn't know how to properly tackle was documenting this change. I can include something in the `README`; however, I wasn't sure if it was required at this time.