### PR TITLE
Make policies responsible for testing client existence

### DIFF
--- a/lib/secure_mirror/default_policy.rb
+++ b/lib/secure_mirror/default_policy.rb
@@ -16,6 +16,10 @@
 module SecureMirror
   # defines a policy for mirror security to enforce
   class DefaultPolicy < Policy
+    def validate!
+      raise(StandardError, 'DefaultPolicy requires a non-nil client') unless @client
+    end
+
     def pre_receive
       # make calls here so that they are cached before update
       org_members

--- a/lib/secure_mirror/policy.rb
+++ b/lib/secure_mirror/policy.rb
@@ -22,7 +22,11 @@ module SecureMirror
       @client = client
       @repo = repo
       @logger = logger
+
+      validate!
     end
+
+    def validate!; end
 
     def pre_receive
       @logger.debug(format('evaluating %<phase>s', phase: @phase))

--- a/lib/secure_mirror/setup.rb
+++ b/lib/secure_mirror/setup.rb
@@ -28,24 +28,24 @@ module SecureMirror
                              config: @config[:repo_types][:github])
     end
 
-    def caching_client(client)
-      conf = @config[:cache]
+    def enable_caching(client)
+      return unless client
+
+      cache = @config[:cache]
+      return client unless cache && cache[:enable]
+
       CachingMirrorClient.new(client,
-                              cache_dir: conf[:dir],
-                              default_expiration: conf[:default_expiration])
+                              cache_dir: cache[:dir],
+                              default_expiration: cache[:default_expiration])
     end
 
     def client
-      case @repo.url.downcase
-      when /github/
-        client = github_client
-      else
-        msg = "unsupported mirror type: #{@repo.url}"
-        raise(StandardError, msg)
-      end
-      return client unless @config[:cache][:enable]
-
-      caching_client(client)
+      enable_caching(
+        case @repo.url.downcase
+        when /github/
+          github_client
+        end
+      )
     end
 
     def policy_class

--- a/spec/secure_mirror/default_policy_spec.rb
+++ b/spec/secure_mirror/default_policy_spec.rb
@@ -75,6 +75,16 @@ RSpec.describe SecureMirror::DefaultPolicy, '#unit' do
   end
   let(:phase) { 'update' }
 
+  describe '#creation' do
+    context 'initialize' do
+      it 'raises an error when client is nil' do
+        expect do
+          SecureMirror::DefaultPolicy.new(config, phase, nil, repo, logger)
+        end.to raise_error StandardError
+      end
+    end
+  end
+
   describe '#collabs_trusted?' do
     context 'when collaborators include untrusted org members' do
       let(:collaborators) { org_members }
@@ -109,12 +119,12 @@ RSpec.describe SecureMirror::DefaultPolicy, '#unit' do
       signoff_bodies = policy.signoff_bodies
       expect(signoff_bodies).to be_a(Hash)
     end
-  
+
     it 'should be case insensitive' do
       signoff_message = config_signoff_bodies[0]
       capitalized_signoff_message = signoff_message.upcase
-      expect(policy.signoff?(signoff_message)).
-        to eq(policy.signoff?(capitalized_signoff_message))
+      expect(policy.signoff?(signoff_message))
+        .to eq(policy.signoff?(capitalized_signoff_message))
     end
 
     it 'returns true when the message is a signoff' do

--- a/spec/secure_mirror/setup_spec.rb
+++ b/spec/secure_mirror/setup_spec.rb
@@ -19,8 +19,7 @@ RSpec.describe SecureMirror::Setup, '#unit' do
   include FakeFS::SpecHelpers
 
   let(:config) do
-    JSON.parse(File.read(config_filename),
-                         symbolize_names: true)
+    JSON.parse(File.read(config_filename), symbolize_names: true)
   end
   let(:config_filename) { __dir__ + '/fixtures/config.json' }
   let(:config_repo) { __dir__ + '/fixtures/config' }
@@ -47,6 +46,16 @@ RSpec.describe SecureMirror::Setup, '#unit' do
   context 'client setup' do
     it 'sets up and returns a client based on config (github)' do
       expect(setup.client).to be
+    end
+  end
+
+  context 'client setup with an unsupported config' do
+    let(:config_repo) { __dir__ + '/fixtures/unsupported-config' }
+    let(:repo) { SecureMirror::GitRepo.new(config_repo) }
+    let(:setup) { SecureMirror::Setup.new(config, repo, logger) }
+
+    it 'does not create a client for an unsupported config' do
+      expect(setup.client).not_to be
     end
   end
 end


### PR DESCRIPTION
It's possible that some policies (like the base policy) don't require a client at all. The policy should decide whether or not a `nil` client is problematic.