### PR TITLE
Correct prefix and expand config path.

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ Starting in version `0.3.0`, this gem includes a script `secure-mirror` which ca
 secure-mirror --enable
 
 # the hook prefix and config file locations are configurable
-secure-mirror --enable --prefix /path/to/git/hook/root --config /path/to/mirror/config.json
+secure-mirror --enable --gitlab-shell-prefix /path/to/git/hook/root --config /path/to/mirror/config.json
 
 # to remove all installed hooks
 secure-mirror --disable

--- a/bin/secure-mirror
+++ b/bin/secure-mirror
@@ -17,7 +17,7 @@ OPTIONS = {
 # rubocop:enable Style/MutableConstant
 
 OptionParser.new do |opt|
-  opt.on('-c', '--config CONFIG') { |o| OPTIONS[:config] = o }
+  opt.on('-c', '--config CONFIG') { |o| OPTIONS[:config] = File.expand_path(o) }
   opt.on('-p', '--gitlab-shell-prefix PREFIX') { |o| OPTIONS[:prefix] = o }
   opt.on('-d', '--disable') { OPTIONS[:enable] = false }
   opt.on('-e', '--enable') { OPTIONS[:enable] = true }


### PR DESCRIPTION
Minor request, it would make sense if the `--config` when enabling expanded the file path automatically.

`secure-mirror --enable  --config example.json`

```
#!/usr/bin/env ruby

require 'secure_mirror'

exit SecureMirror.evaluate_changes(
  'pre-receive',
  'gitlab',
  config_file: '/Users/Shared/ornldev/projects/ecp/paulbry/remote-mirror-security/example.json'
)
```

Also, the documentation specified `--gitlab-shell-prefix` in docs.