### PR TITLE
Avoid using undefined/nil logger method.

### DIFF
--- a/lib/secure_mirror.rb
+++ b/lib/secure_mirror.rb
@@ -114,9 +114,11 @@ module SecureMirror
     setup = Setup.new(config, repo, logger)
     setup.policy_class.new(config, phase, setup.client, repo, logger).evaluate
   rescue StandardError => e
-    # if anything goes wrong, cancel the changes
-    logger.error(e)
-    logger.debug(e.backtrace.join("\n"))
+    if defined?(logger) && !logger.nil?
+      # if anything goes wrong, cancel the changes
+      logger.error(e)
+      logger.debug(e.backtrace.join("\n"))
+    end
     SecureMirror::Codes::GENERAL_ERROR
   end
 end


### PR DESCRIPTION
I'm unsure about this request, so I can retract it.

An error in the config/logger setup will result in: `undefined method `error' for nil:NilClass (NoMethodError)`. I think this is a rehearing (as the issue is likely with the configuration) and presents the fully panic to the user.