### PR TITLE
Return an empty list of collabs when unauthorized

### DIFF
--- a/lib/secure_mirror/github_mirror_client.rb
+++ b/lib/secure_mirror/github_mirror_client.rb
@@ -63,9 +63,13 @@ module SecureMirror
     def collaborators(repo, client_name: '')
       wrap_with_github_error_handler(template: COLLABORATOR_ERROR, repo: repo) do
         client = client_from_name(client_name.to_sym)
-        client.collabs(repo).select { |c| write_perms?(c) }.map do |collab|
-          [collab[:login], Collaborator.new(collab[:login], false)]
-        end.to_h
+        begin
+          client.collabs(repo).select { |c| write_perms?(c) }.map do |collab|
+            [collab[:login], Collaborator.new(collab[:login], false)]
+          end.to_h
+        rescue Octokit::Forbidden
+          []
+        end
       end
     end
 

--- a/spec/secure_mirror/github_mirror_client_spec.rb
+++ b/spec/secure_mirror/github_mirror_client_spec.rb
@@ -101,6 +101,13 @@ RSpec.describe SecureMirror::GitHubMirrorClient, '#client' do
       expect(collabs.any? { |k, _| member_with_read[:login] == k }).to be false
     end
 
+    it 'has an empty list of collaborators when unauthorized' do
+      allow(mirror_client.client).to receive(:collabs) { raise Octokit::Forbidden }
+
+      collabs = mirror_client.collaborators(repo)
+      expect(collabs.empty?).to be true
+    end
+
     it 'gathers review comments' do
       # comments = mirror_client.review_comments(repo, sha)
       # expect(comments).to eq []


### PR DESCRIPTION
When the hook is repeatedly called on a repository where it does not
have permissions to access the organization, it will consistently get
unauthorized HTTP responses back. It won't change over time and at worst
it could cause the webserver to limit requests. By returning an empty
list, this change allows sets the cache to be empty and thus not make
repeated requests that will fail.